### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/chainer/mecab-python-0.996/MeCab.py
+++ b/chainer/mecab-python-0.996/MeCab.py
@@ -43,7 +43,7 @@ def _swig_setattr_nondynamic(self,class_type,name,value,static=1):
     if (not static):
         self.__dict__[name] = value
     else:
-        raise AttributeError("You cannot add attributes to %s" % self)
+        raise AttributeError("You cannot add attributes to {0!s}".format(self))
 
 def _swig_setattr(self,class_type,name,value):
     return _swig_setattr_nondynamic(self,class_type,name,value,0)
@@ -57,7 +57,7 @@ def _swig_getattr(self,class_type,name):
 def _swig_repr(self):
     try: strthis = "proxy of " + self.this.__repr__()
     except: strthis = ""
-    return "<%s.%s; %s >" % (self.__class__.__module__, self.__class__.__name__, strthis,)
+    return "<{0!s}.{1!s}; {2!s} >".format(self.__class__.__module__, self.__class__.__name__, strthis)
 
 try:
     _object = object

--- a/chainer/mecab-python-0.996/build/lib.macosx-10.9-intel-2.7/MeCab.py
+++ b/chainer/mecab-python-0.996/build/lib.macosx-10.9-intel-2.7/MeCab.py
@@ -43,7 +43,7 @@ def _swig_setattr_nondynamic(self,class_type,name,value,static=1):
     if (not static):
         self.__dict__[name] = value
     else:
-        raise AttributeError("You cannot add attributes to %s" % self)
+        raise AttributeError("You cannot add attributes to {0!s}".format(self))
 
 def _swig_setattr(self,class_type,name,value):
     return _swig_setattr_nondynamic(self,class_type,name,value,0)
@@ -57,7 +57,7 @@ def _swig_getattr(self,class_type,name):
 def _swig_repr(self):
     try: strthis = "proxy of " + self.this.__repr__()
     except: strthis = ""
-    return "<%s.%s; %s >" % (self.__class__.__module__, self.__class__.__name__, strthis,)
+    return "<{0!s}.{1!s}; {2!s} >".format(self.__class__.__module__, self.__class__.__name__, strthis)
 
 try:
     _object = object

--- a/chainer/mecab-python-0.996/test.py
+++ b/chainer/mecab-python-0.996/test.py
@@ -29,22 +29,22 @@ try:
         b = lattice.begin_nodes(i)
         e = lattice.end_nodes(i)
         while b:
-            print "B[%d] %s\t%s" % (i, b.surface, b.feature)
+            print "B[{0:d}] {1!s}\t{2!s}".format(i, b.surface, b.feature)
             b = b.bnext 
         while e:
-            print "E[%d] %s\t%s" % (i, e.surface, e.feature)
+            print "E[{0:d}] {1!s}\t{2!s}".format(i, e.surface, e.feature)
             e = e.bnext 
     print "EOS";
 
     d = t.dictionary_info()
     while d:
-        print "filename: %s" % d.filename
-        print "charset: %s" %  d.charset
-        print "size: %d" %  d.size
-        print "type: %d" %  d.type
-        print "lsize: %d" %  d.lsize
-        print "rsize: %d" %  d.rsize
-        print "version: %d" %  d.version
+        print "filename: {0!s}".format(d.filename)
+        print "charset: {0!s}".format(d.charset)
+        print "size: {0:d}".format(d.size)
+        print "type: {0:d}".format(d.type)
+        print "lsize: {0:d}".format(d.lsize)
+        print "rsize: {0:d}".format(d.rsize)
+        print "version: {0:d}".format(d.version)
         d = d.next
 
 except RuntimeError, e:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mitakeck:study?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mitakeck:study?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)